### PR TITLE
Update SsidBlackListBootstraper.java

### DIFF
--- a/android/app/src/main/java/org/openbmap/services/wireless/blacklists/SsidBlackListBootstraper.java
+++ b/android/app/src/main/java/org/openbmap/services/wireless/blacklists/SsidBlackListBootstraper.java
@@ -128,6 +128,7 @@ public final class SsidBlackListBootstraper {
 		{"Swiss Post Auto Wifi Italian", "AutoPostale"},
 		{"Huawei Smartphones", "Huawei"},
 		{"Huawei Smartphones", "huawei"},
+		{"Android error", "NVRAM WARNING"},
 		
 		// mobile hotspots
 		{"German 1und1 mobile hotspots", "1und1 mobile"},


### PR DESCRIPTION
I added to the filter-list non-existent Wi-Fi network "NVRAM WARNING..." with mac address 00:00:00:00:00:00.